### PR TITLE
shopfloor_mobile: fix parsing of location containing an int

### DIFF
--- a/shopfloor_mobile/static/wms/src/scenario/cluster_batch_picking.js
+++ b/shopfloor_mobile/static/wms/src/scenario/cluster_batch_picking.js
@@ -242,7 +242,7 @@ const ClusterBatchPicking = {
                         }
                     },
                     on_scan: scanned => {
-                        const intInText = parseInt(scanned.text);
+                        const intInText = "" + scanned.text == parseInt(scanned.text, 10) && parseInt(scanned.text, 10);
                         let move_line = this.find_move_line(
                             this.state.data.move_lines,
                             scanned.text,


### PR DESCRIPTION
"2a" or "a2" should be recognized as barcode for location